### PR TITLE
Normalize data responses

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -97,6 +97,9 @@ router.post('/login', async (req, res) => {
         title: 'Login Successful',
         detail: 'Successfully validated user credentials',
         csrfToken: session.csrfToken,
+        user: {
+          email: user.email
+        },
       });
   } catch (err) {
     res.status(401).json({

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -115,11 +115,11 @@ router.get('/me', authenticate, async (req, res) => {
   try {
     const { userId } = req.session;
     const user = await User.findById({ _id: userId }, { email: 1, _id: 0 });
-
     res.json({
       title: 'Authentication successful',
       detail: 'Successfully authenticated user',
       user,
+      csrfToken: req.session.csrfToken
     });
   } catch (err) {
     res.status(401).json({


### PR DESCRIPTION
First of all, THANK YOU for making this.

I used this boilerplate repo for a quick project to refresh my memory on CSRF tokens.

I ran into some issues with the `/me` and `/login` responses missing data while using this project so thought I would make a PR

For `/me`, if the user is already logged in and returns to the app, they don't have the CSRF token to `logout` or make other write requests to the server.

For `/login`, the email is needed to mirror the response you would get from `/me`. 